### PR TITLE
feat: show progress and outcome for OCR capture

### DIFF
--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -2413,13 +2413,18 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           // Secure pixels first: immediately after the snapshot is taken, dismiss the overlay.
           AreaSelectionController.shared.cancelSelection()
 
-          let progressToast = AppToastManager.shared.show(
-            message: L10n.OCR.capturingContent,
-            style: .info,
-            duration: nil,
-            variant: .compact,
-            iconMode: .spinner
-          )
+          // The menu-bar spinner is the primary progress surface, but `setProcessing` is a no-op
+          // without a status item, so it reports nothing when the icon is hidden. Fall back to a
+          // toast only in that case, never alongside it.
+          let progressToast = AppStatusBarController.shared.isMenuBarIconVisible
+            ? nil
+            : AppToastManager.shared.show(
+              message: L10n.OCR.capturingContent,
+              style: .info,
+              duration: nil,
+              variant: .compact,
+              iconMode: .spinner
+            )
 
           Task { @MainActor in
             var progressToastResolved = false

--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -2413,10 +2413,30 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           // Secure pixels first: immediately after the snapshot is taken, dismiss the overlay.
           AreaSelectionController.shared.cancelSelection()
 
+          // Shown synchronously on mouse-up so the feedback lands before the first async hop, and
+          // only after the snapshots above are secured so the panel cannot reach the captured
+          // pixels. One label covers the whole operation: the capture step only crops the snapshot
+          // already taken, which completes well inside the toast's own fade-in.
+          let progressToast = AppToastManager.shared.show(
+            message: L10n.OCR.capturingContent,
+            style: .info,
+            duration: nil,
+            variant: .compact,
+            iconMode: .spinner
+          )
+
           Task { @MainActor in
+            // Set once the toast has been given a terminal state, so the cleanup below leaves it
+            // alone. `OCRResultNotifier` prefers a native notification and shows no toast when one
+            // is delivered, and reports from a detached task that resolves after this scope exits,
+            // so an unconditional dismiss would always win the race.
+            var progressToastResolved = false
             defer {
               self.isAreaSelectionActive = false
               hiddenWindowSession.restore()
+              if let progressToast, !progressToastResolved {
+                AppToastManager.shared.dismiss(progressToast)
+              }
             }
             await Task.yield()
 
@@ -2470,6 +2490,20 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
               AppStatusBarController.shared.setProcessing(false)
 
               guard let clipboardText else {
+                // Same reasoning as the success path — a silent dismissal is least helpful
+                // exactly when nothing was found.
+                if let progressToast {
+                  AppToastManager.shared.update(
+                    progressToast,
+                    message: qrResult.unsupportedPayloadCount > 0
+                      ? L10n.OCR.qrTextOnlyUnsupported
+                      : L10n.OCR.noTextFound,
+                    style: .warning,
+                    duration: 2.5,
+                    variant: .compact
+                  )
+                  progressToastResolved = true
+                }
                 if qrResult.unsupportedPayloadCount > 0 {
                   var context = performanceContext
                   context["unsupportedQRCount"] = "\(qrResult.unsupportedPayloadCount)"
@@ -2502,6 +2536,20 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
               successContext["qrCount"] = "\(qrResult.detections.count)"
               successContext["unsupportedQRCount"] = "\(qrResult.unsupportedPayloadCount)"
               DiagnosticLogger.shared.log(.info, .ocr, "OCR text copied to clipboard", context: successContext)
+
+              // Land on a success state rather than dismissing: the preferred notification is
+              // easy to miss and is suppressed entirely by Focus.
+              if let progressToast {
+                AppToastManager.shared.update(
+                  progressToast,
+                  message: L10n.Common.copiedToClipboard,
+                  style: .success,
+                  duration: 2.0,
+                  variant: .compact
+                )
+                progressToastResolved = true
+              }
+
               OCRResultNotifier.shared.report(.copied(clipboardText))
               if OCRResultNotifier.isEnabled() {
                 QuickAccessSound.complete.play()
@@ -2520,6 +2568,16 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
               // Error feedback
               AppStatusBarController.shared.setProcessing(false)
               DiagnosticLogger.shared.logError(.ocr, error, "OCR capture failed")
+              if let progressToast {
+                AppToastManager.shared.update(
+                  progressToast,
+                  message: error.localizedDescription,
+                  style: .error,
+                  duration: 2.5,
+                  variant: .compact
+                )
+                progressToastResolved = true
+              }
               OCRResultNotifier.shared.report(.failed(errorDescription: error.localizedDescription))
               QuickAccessSound.failed.play()
             }

--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -2413,9 +2413,6 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           // Secure pixels first: immediately after the snapshot is taken, dismiss the overlay.
           AreaSelectionController.shared.cancelSelection()
 
-          // The menu-bar spinner is the primary progress surface, but `setProcessing` is a no-op
-          // without a status item, so it reports nothing when the icon is hidden. Fall back to a
-          // toast only in that case, never alongside it.
           let progressToast = AppStatusBarController.shared.isMenuBarIconVisible
             ? nil
             : AppToastManager.shared.show(

--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -2413,10 +2413,6 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           // Secure pixels first: immediately after the snapshot is taken, dismiss the overlay.
           AreaSelectionController.shared.cancelSelection()
 
-          // Shown synchronously on mouse-up so the feedback lands before the first async hop, and
-          // only after the snapshots above are secured so the panel cannot reach the captured
-          // pixels. One label covers the whole operation: the capture step only crops the snapshot
-          // already taken, which completes well inside the toast's own fade-in.
           let progressToast = AppToastManager.shared.show(
             message: L10n.OCR.capturingContent,
             style: .info,
@@ -2426,10 +2422,6 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           )
 
           Task { @MainActor in
-            // Set once the toast has been given a terminal state, so the cleanup below leaves it
-            // alone. `OCRResultNotifier` prefers a native notification and shows no toast when one
-            // is delivered, and reports from a detached task that resolves after this scope exits,
-            // so an unconditional dismiss would always win the race.
             var progressToastResolved = false
             defer {
               self.isAreaSelectionActive = false
@@ -2490,8 +2482,6 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
               AppStatusBarController.shared.setProcessing(false)
 
               guard let clipboardText else {
-                // Same reasoning as the success path — a silent dismissal is least helpful
-                // exactly when nothing was found.
                 if let progressToast {
                   AppToastManager.shared.update(
                     progressToast,
@@ -2537,8 +2527,6 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
               successContext["unsupportedQRCount"] = "\(qrResult.unsupportedPayloadCount)"
               DiagnosticLogger.shared.log(.info, .ocr, "OCR text copied to clipboard", context: successContext)
 
-              // Land on a success state rather than dismissing: the preferred notification is
-              // easy to miss and is suppressed entirely by Focus.
               if let progressToast {
                 AppToastManager.shared.update(
                   progressToast,

--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -1301,6 +1301,71 @@
         }
       }
     },
+    "ocr.capturing-content": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfassen..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturing..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturando..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture en cours..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャ中..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처 중..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Захват..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang chụp..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截取中..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "擷取中..."
+          }
+        }
+      }
+    },
     "ocr.extracting-content": {
       "extractionState": "stale",
       "localizations": {

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -7609,6 +7609,11 @@ nonisolated enum L10n {
   }
 
   enum OCR {
+    static let capturingContent = string(
+      "ocr.capturing-content",
+      defaultValue: "Capturing...",
+      comment: "Progress toast shown the moment an OCR capture starts, while the selected area is still being captured"
+    )
     static let extractingContent = string(
       "ocr.extracting-content",
       defaultValue: "Extracting content...",


### PR DESCRIPTION
An OCR capture reports nothing between mouse-up and the text landing on the clipboard except the menu-bar spinner, so a slow recognition reads as a freeze.

### Progress

A toast now appears synchronously on mouse-up, before the first async hop. It is shown only after the mouse-up snapshots are secured, so the panel can never end up in the captured pixels.

One label covers the whole operation. Relabelling once the image is in hand sounds better but is not: the normal path only crops the snapshot already taken at mouse-up, which finishes well inside the toast's own fade-in, so the first label never became visible.

### Outcome

The toast resolves into a terminal state rather than being dismissed. `OCRResultNotifier` prefers a native notification and deliberately shows no toast when one is delivered, and it reports from a detached task that resolves after the capture scope exits - so an unconditional dismiss always won the race and the spinner vanished into nothing.

Each exit now lands on a visible outcome:

| Outcome | Toast |
| --- | --- |
| Text copied | success, "Copied to clipboard" |
| No text found | warning |
| QR-only, unsupported payload | warning |
| Capture or recognition threw | error, with the description |

Notification behaviour is unchanged - this only adds the in-app confirmation for users who miss it, or who have Focus enabled and never receive it.

### Notes

Reuses the existing `AppToastManager` spinner presentation already used by the Annotate editor's OCR, so no new UI. Adds one string, `ocr.capturing-content`, localized across all ten supported languages.