### PR TITLE
fix: keep keystroke badges above elevated app windows

### DIFF
--- a/Snapzy/Features/Recording/Managers/KeystrokeOverlayWindow.swift
+++ b/Snapzy/Features/Recording/Managers/KeystrokeOverlayWindow.swift
@@ -38,7 +38,7 @@ final class KeystrokeOverlayWindow: NSWindow {
     backgroundColor = .clear
     hasShadow = false
     isReleasedWhenClosed = false
-    level = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue + 1)
+    level = .screenSaver
     collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     ignoresMouseEvents = true
   }

--- a/SnapzyTests/Features/Recording/KeystrokeOverlayWindowTests.swift
+++ b/SnapzyTests/Features/Recording/KeystrokeOverlayWindowTests.swift
@@ -1,0 +1,17 @@
+import AppKit
+import XCTest
+@testable import Snapzy
+
+@MainActor
+final class KeystrokeOverlayWindowTests: XCTestCase {
+  func testOverlayStaysAboveStatusLevelWindowsWithoutInterceptingInput() {
+    let window = KeystrokeOverlayWindow(recordingRect: CGRect(x: 0, y: 0, width: 400, height: 200))
+    defer { window.close() }
+
+    XCTAssertGreaterThan(window.level.rawValue, NSWindow.Level.statusBar.rawValue)
+    XCTAssertTrue(window.ignoresMouseEvents)
+    XCTAssertFalse(window.canBecomeKey)
+    XCTAssertFalse(window.canBecomeMain)
+    XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
+  }
+}


### PR DESCRIPTION
## Problem
The keystroke overlay uses floating + 1, so application windows at higher levels can cover the badge while recording.

## Change
Use the native screenSaver window level for the keystroke overlay. It remains click-through, cannot become key or main, and retains its existing full-screen auxiliary behavior. This is independent of the event-capture changes in #539.

## Validation
- Added a regression test for ordering above status-level windows, mouse passthrough, non-key/non-main behavior, and full-screen auxiliary behavior.
- Confirmed the test fails before the change (level 4 is not above level 25) and passes after it.
- Built and tested on macOS with Xcode 26.5.
- Previously verified the badge above an elevated application overlay in a local recording session.
- No changes to event capture or recording filters.