### PR TITLE
fix: isolate annotation viewport events per window

### DIFF
--- a/Snapzy/Features/Annotate/AnnotateMainView.swift
+++ b/Snapzy/Features/Annotate/AnnotateMainView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// Main container for annotation window layout
 struct AnnotateMainView: View {
   @StateObject var state: AnnotateState
+  let eventRouter: AnnotateWindowEventRouter
   @ObservedObject private var themeManager = ThemeManager.shared
   private let quickPropertiesBarHeight: CGFloat = 48
 
@@ -42,7 +43,7 @@ struct AnnotateMainView: View {
             .background(Color.white.opacity(0.1))
         }
 
-        AnnotateCanvasView(state: state)
+        AnnotateCanvasView(state: state, eventRouter: eventRouter)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .contentShape(Rectangle()) // Constrain hit-test area to frame bounds
           .clipped() // Prevent canvas content from overlapping toolbar/bottombar
@@ -51,7 +52,7 @@ struct AnnotateMainView: View {
       Divider()
         .background(Color(nsColor: .separatorColor))
 
-      AnnotateBottomBarView(state: state)
+      AnnotateBottomBarView(state: state, eventRouter: eventRouter)
     }
     .preferredColorScheme(themeManager.systemAppearance)
     .ignoresSafeArea(.all, edges: .top) // Extend background behind title bar

--- a/Snapzy/Features/Annotate/Components/AnnotateBottomBarView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateBottomBarView.swift
@@ -44,6 +44,7 @@ private extension View {
 /// Bottom bar containing zoom controls and action buttons
 struct AnnotateBottomBarView: View {
   @ObservedObject var state: AnnotateState
+  let eventRouter: AnnotateWindowEventRouter
   @ObservedObject private var cloudManager = CloudManager.shared
   @ObservedObject private var preferencesManager = PreferencesManager.shared
   @ObservedObject private var annotateShortcutManager = AnnotateShortcutManager.shared
@@ -97,7 +98,7 @@ struct AnnotateBottomBarView: View {
     } message: {
       Text(L10n.AnnotateUI.overwriteCloudFileMessage)
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateCloudUpload)) { _ in
+    .onReceive(eventRouter.publisher(for: .annotateCloudUpload)) { _ in
       // ⌘U shortcut: trigger cloud upload (with overwrite confirmation if needed)
       let showCloudButton = cloudManager.isConfigured && QuickAccessActionConfigurationStore.shared.isEnabled(.uploadToCloud)
       let needsReUpload = state.requiresRenderedOutputForSharing || state.isCloudStale

--- a/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
@@ -61,6 +61,7 @@ enum AnnotateImageDropLoader {
 /// Canvas view for displaying and annotating the image
 struct AnnotateCanvasView: View {
   @ObservedObject var state: AnnotateState
+  let eventRouter: AnnotateWindowEventRouter
   @FocusState private var isCanvasFocused: Bool
   @State private var isDragOver = false
   @State private var showDropError = false
@@ -106,7 +107,7 @@ struct AnnotateCanvasView: View {
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateScrollZoom)) { notification in
+    .onReceive(eventRouter.publisher(for: .annotateScrollZoom)) { notification in
       guard state.hasImage,
             let delta = notification.userInfo?["delta"] as? CGFloat else { return }
       let step = delta * 0.1
@@ -114,47 +115,47 @@ struct AnnotateCanvasView: View {
         state.zoomLevel = state.clampedZoom(state.zoomLevel + step)
       }
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateMagnifyZoom)) { notification in
+    .onReceive(eventRouter.publisher(for: .annotateMagnifyZoom)) { notification in
       guard state.hasImage,
             let magnification = notification.userInfo?["magnification"] as? CGFloat else { return }
       withAnimation(.easeOut(duration: 0.1)) {
         state.zoomLevel = state.clampedZoom(state.zoomLevel + magnification)
       }
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateZoomIn)) { _ in
+    .onReceive(eventRouter.publisher(for: .annotateZoomIn)) { _ in
       guard state.hasImage else { return }
       withAnimation(.easeOut(duration: 0.15)) {
         state.zoomLevel = state.clampedZoom(state.zoomLevel + 0.25)
       }
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateZoomOut)) { _ in
+    .onReceive(eventRouter.publisher(for: .annotateZoomOut)) { _ in
       guard state.hasImage else { return }
       withAnimation(.easeOut(duration: 0.15)) {
         state.zoomLevel = state.clampedZoom(state.zoomLevel - 0.25)
       }
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateZoomReset)) { _ in
+    .onReceive(eventRouter.publisher(for: .annotateZoomReset)) { _ in
       guard state.hasImage else { return }
       withAnimation(.easeOut(duration: 0.15)) {
         state.zoomLevel = 1.0
       }
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateSpaceDown)) { _ in
+    .onReceive(eventRouter.publisher(for: .annotateSpaceDown)) { _ in
       guard state.hasImage,
             state.canPanInteractively,
             state.editingTextAnnotationId == nil else { return }
       state.isSpacePanning = true
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotateSpaceUp)) { _ in
+    .onReceive(eventRouter.publisher(for: .annotateSpaceUp)) { _ in
       state.isSpacePanning = false
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotatePanDrag)) { notification in
+    .onReceive(eventRouter.publisher(for: .annotatePanDrag)) { notification in
       guard state.isSpacePanning || state.isCanvasPanningMode,
             let dx = notification.userInfo?["deltaX"] as? CGFloat,
             let dy = notification.userInfo?["deltaY"] as? CGFloat else { return }
       state.pan(by: CGSize(width: dx, height: dy))
     }
-    .onReceive(NotificationCenter.default.publisher(for: .annotatePanScroll)) { notification in
+    .onReceive(eventRouter.publisher(for: .annotatePanScroll)) { notification in
       guard state.hasImage,
             state.canPanInteractively,
             state.editingTextAnnotationId == nil,

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Combine
 
 // MARK: - Notifications
 
@@ -29,6 +30,26 @@ extension Notification.Name {
   static let annotateSpaceUp = Notification.Name("annotateSpaceUp")
   static let annotatePanDrag = Notification.Name("annotatePanDrag")
   static let annotatePanScroll = Notification.Name("annotatePanScroll")
+}
+
+/// Routes full-editor notifications to the view tree belonging to one window.
+/// The weak reference keeps the SwiftUI content from retaining a closed window.
+final class AnnotateWindowEventRouter {
+  private weak var window: NSWindow?
+
+  init(window: NSWindow) {
+    self.window = window
+  }
+
+  func publisher(for name: Notification.Name) -> AnyPublisher<Notification, Never> {
+    NotificationCenter.default.publisher(for: name)
+      .filter { [weak self] notification in
+        guard let object = notification.object as? NSWindow,
+              let window = self?.window else { return false }
+        return object === window
+      }
+      .eraseToAnyPublisher()
+  }
 }
 
 enum AnnotateObjectShortcut: Equatable {

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -248,7 +248,9 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
 
   private func setupContent() {
     let capturedState = self.state
-    let mainView = AnnotateMainView(state: capturedState)
+    guard let annotateWindow = window as? AnnotateWindow else { return }
+    let eventRouter = AnnotateWindowEventRouter(window: annotateWindow)
+    let mainView = AnnotateMainView(state: capturedState, eventRouter: eventRouter)
     window?.contentView = NSHostingView(rootView: mainView)
     (window as? AnnotateWindow)?.onEscape = { [weak self] in
       self?.discardEditsAndClose() ?? false

--- a/SnapzyTests/Features/Annotate/AnnotateViewportUIStateTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateViewportUIStateTests.swift
@@ -10,7 +10,9 @@
 //  duplicated here.
 //
 
+import AppKit
 import CoreGraphics
+import SwiftUI
 import XCTest
 @testable import Snapzy
 
@@ -73,6 +75,79 @@ final class AnnotateViewportUIStateTests: XCTestCase {
 
     // percent/100 / fitScale = 1.0 / 0.5 = 2.0, still within [0.25, max].
     XCTAssertEqual(state.zoomLevel(forDisplayedPercent: 100), 2.0, accuracy: 0.0001)
+  }
+
+  @MainActor
+  func testZoomShortcutOnlyUpdatesTheOriginatingAnnotationWindow() {
+    let stateA = makeAnnotateStateWithImage()
+    let stateB = makeAnnotateStateWithImage()
+    let windowA = makeAnnotationWindow(state: stateA)
+    let windowB = makeAnnotationWindow(state: stateB)
+    defer {
+      windowA.close()
+      windowB.close()
+      windowA.contentView = nil
+      windowB.contentView = nil
+    }
+
+    windowA.makeKeyAndOrderFront(nil)
+    windowB.orderFrontRegardless()
+    drainMainRunLoop()
+
+    let event = NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: .command,
+      timestamp: 0,
+      windowNumber: windowA.windowNumber,
+      context: nil,
+      characters: "=",
+      charactersIgnoringModifiers: "=",
+      isARepeat: false,
+      keyCode: 24
+    )
+
+    XCTAssertNotNil(event)
+    XCTAssertTrue(windowA.performKeyEquivalent(with: event!))
+    drainMainRunLoop()
+
+    XCTAssertEqual(stateA.zoomLevel, 1.25, accuracy: 0.0001)
+    XCTAssertEqual(stateB.zoomLevel, 1.0, accuracy: 0.0001)
+
+    stateA.updateViewportMetrics(
+      containerSize: CGSize(width: 200, height: 200),
+      baseCanvasSize: CGSize(width: 1_000, height: 1_000),
+      fitScale: 1.0
+    )
+    stateB.updateViewportMetrics(
+      containerSize: CGSize(width: 200, height: 200),
+      baseCanvasSize: CGSize(width: 1_000, height: 1_000),
+      fitScale: 1.0
+    )
+
+    NotificationCenter.default.post(name: .annotateSpaceDown, object: windowA)
+    NotificationCenter.default.post(
+      name: .annotatePanDrag,
+      object: windowA,
+      userInfo: ["deltaX": CGFloat(24), "deltaY": CGFloat(-12)]
+    )
+    drainMainRunLoop()
+
+    XCTAssertTrue(stateA.isSpacePanning)
+    XCTAssertFalse(stateB.isSpacePanning)
+    XCTAssertEqual(stateA.panOffset.width, 24, accuracy: 0.0001)
+    XCTAssertEqual(stateA.panOffset.height, -12, accuracy: 0.0001)
+    XCTAssertEqual(stateB.panOffset, .zero)
+
+    NotificationCenter.default.post(name: .annotateSpaceUp, object: windowA)
+    drainMainRunLoop()
+    XCTAssertFalse(stateA.isSpacePanning)
+    XCTAssertFalse(stateB.isSpacePanning)
+
+    windowA.close()
+    drainMainRunLoop()
+    XCTAssertEqual(stateB.zoomLevel, 1.0, accuracy: 0.0001)
+    XCTAssertEqual(stateB.panOffset, .zero)
   }
 
   // MARK: - Pan
@@ -318,5 +393,29 @@ final class AnnotateViewportUIStateTests: XCTestCase {
     state.markAsSaved()
 
     XCTAssertFalse(state.hasUnsavedChanges)
+  }
+
+  @MainActor
+  private func makeAnnotateStateWithImage() -> AnnotateState {
+    let state = AnnotateState(
+      image: NSImage(size: NSSize(width: 100, height: 100)),
+      url: URL(fileURLWithPath: "/tmp/annotate-window-isolation.png")
+    )
+    Self.retainedAnnotateStates.append(state)
+    return state
+  }
+
+  @MainActor
+  private func makeAnnotationWindow(state: AnnotateState) -> AnnotateWindow {
+    let window = AnnotateWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 600))
+    window.interactionState = state
+    let eventRouter = AnnotateWindowEventRouter(window: window)
+    window.contentView = NSHostingView(rootView: AnnotateCanvasView(state: state, eventRouter: eventRouter))
+    return window
+  }
+
+  @MainActor
+  private func drainMainRunLoop() {
+    RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
   }
 }

--- a/docs/ANNOTATE.md
+++ b/docs/ANNOTATE.md
@@ -6,7 +6,7 @@ Snapzy's annotation subsystem: the full Annotate editor window (hybrid AppKit sh
 
 - `Snapzy/Features/Annotate/AnnotateManager.swift` — singleton window registry; session cache keyed by `QuickAccessItem.id`; activation policy bump to `.regular` on open; `openAnnotation(for:)` (QA item) / `openAnnotation(url:sessionData:)` / `openEmptyAnnotation()`.
 - `Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift` — per-window controller, owns save/copy/close notifications.
-- `Snapzy/Features/Annotate/Managers/AnnotateWindow.swift` — `NSWindow` subclass; intercepts ⌘+scroll zoom, trackpad magnify, Space key (pan mode via `annotateSpaceDown/Up` notifications), drag events; level floats while key (`activeEditorLevel`) and restores `restingLevel` on resign; pin sets resting level `.floating`.
+- `Snapzy/Features/Annotate/Managers/AnnotateWindow.swift` — `NSWindow` subclass; intercepts ⌘+scroll zoom, trackpad magnify, Space key (pan mode via `annotateSpaceDown/Up` notifications), drag events; level floats while key (`activeEditorLevel`) and restores `restingLevel` on resign; pin sets resting level `.floating`. `AnnotateWindowEventRouter` scopes these input notifications (and cloud-upload actions) to the originating window, so each full editor keeps isolated viewport and UI state.
 - `Snapzy/Features/Annotate/AnnotateState.swift` — central `ObservableObject` (~4.8k lines): annotations, tools, undo/redo, zoom/pan, canvas effects, crop, cutout, mockup, combine, cloud state.
 - Layout (`AnnotateMainView`): `AnnotateToolbarView` → `AnnotateQuickPropertiesBar` → `HStack(AnnotateSidebarView 240pt | AnnotateCanvasView)` → `AnnotateBottomBarView`.
 - Rendering: `DrawingCanvasNSView` (AppKit event container) + 5 stacked `CanvasLayerView`s composited by CoreAnimation — spotlight overlay → static-below → dragged → static-above → gesture preview. Static layers redraw only when invalidated (CA reuses their backing store), so per-frame cost is flat in annotation count and colors always render through the standard pipeline (no offscreen bitmap color management). Deterministic export via `AnnotateExporter.renderFinalImage` (mockup: `renderMockupFlatImage` off-main + `compositeMockupImage` on main — `ImageRenderer` is main-only).
@@ -100,6 +100,7 @@ The `.accessory` activation-policy revert is deferred to a later runloop turn (s
 
 - Range 0.25–16x: `minimumZoomLevel 0.25`, default max 4.0, `hardMaximumZoomLevel 16.0`; `effectiveMaximumZoomLevel` grows to `1/fitScale` for very long captures.
 - Input: pinch magnification, ⌘+scroll, Space+drag pan, ⌘=/⌘−/⌘0 (fit); zoom picker presets + `1:1` actual-pixels in bottom bar.
+- Full-editor AppKit input is delivered through the per-window `AnnotateWindowEventRouter`; zoom, pan, and Space transitions update only the `AnnotateState` owned by the originating window. Session edits, viewport metrics, and undo state remain controller-local; shared shortcut, palette, and preset stores are preferences, not editor state.
 
 ## Backgrounds & Mockups
 


### PR DESCRIPTION
## 1. Purpose & Motivation (Why)

* **Description:** Fixes an annotation workflow bug where zooming, panning, or holding Space in one open annotation window propagated to every other annotation window. Each editor must retain independent viewport and UI state.
* **Ticket Link(s):** Closes #551
* **Context & Flow:** `AnnotateWindow` emits input notifications with the originating window as the notification object. The previous SwiftUI subscribers listened globally, so every open canvas handled every window's event. This PR establishes the intended flow:

  `AppKit window event → per-window event router → matching SwiftUI view tree → owning AnnotateState`

## 2. Key Changes (What)

* Added `AnnotateWindowEventRouter`, a per-window event boundary that filters notifications by window identity and uses a weak window reference.
* Scoped zoom-in, zoom-out, reset, scroll zoom, magnification, pan, and Space transitions to the originating annotation window.
* Scoped cloud-upload shortcut handling as the same class of cross-window event leak.
* Passed the router through `AnnotateWindowController`, `AnnotateMainView`, `AnnotateCanvasView`, and `AnnotateBottomBarView`.
* Added a two-window regression test covering simultaneous zoom/pan/Space interactions and closing one window without affecting the other.
* Updated annotation architecture documentation.
* **Recommended Review Order:** `AnnotateWindowEventRouter` and AppKit event emission → window controller/root-view wiring → canvas and bottom-bar subscriptions → regression test.
* **Critical Modules/Files:** `Snapzy/Features/Annotate/Managers/AnnotateWindow.swift`, `Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift`, and `Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift`.
* **Technical Decisions:** The fix isolates event delivery at the publisher boundary instead of adding active-window conditionals inside state handlers. `AnnotateState` remains instance-owned per controller; no shared mutable editor state or persisted-data migration is introduced.

## 3. Verification & Testing (How)

* **Reproduction:** Opened two real `AnnotateWindow` instances simultaneously. Before the fix, Cmd+= in window A changed both window states; the regression test failed because window B became 1.25x. After the fix, only window A changes, and closing A leaves window B unchanged.
* **Focused regression:** `./scripts/run-tests.sh -only-testing:SnapzyTests/AnnotateViewportUIStateTests/testZoomShortcutOnlyUpdatesTheOriginatingAnnotationWindow`
* **Annotation test coverage:** All annotation-targeted tests pass with 0 failures in the xcresult summary.
* **Build:** `xcodebuild -project Snapzy.xcodeproj -scheme Snapzy -configuration Debug build` passes.
* **Full repository suite:** Four environment-sensitive failures remain outside the changed files: `SnapzyConfigurationServiceTests`, `RecordingSessionHotkeyRegistrationTests`, and two `AreaSelectionMultiMonitorReconciliationTests` cases.
